### PR TITLE
Add context details to stake and redeem forms

### DIFF
--- a/src/app/vault/page.tsx
+++ b/src/app/vault/page.tsx
@@ -250,6 +250,20 @@ export default function VaultPage() {
                       usdValue={stakeValue}
                     />
                   </div>
+                  <div className="space-y-1 text-sm">
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Exchange rate</span>
+                      <span className="text-right">{`1 MNV = $${price.toFixed(2)}`}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Staking fee</span>
+                      <span className="text-right">Free for now</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Redemption term</span>
+                      <span className="text-right">10 day cooldown</span>
+                    </div>
+                  </div>
                   <Button type="submit" className="w-full">
                     Stake
                   </Button>
@@ -283,6 +297,22 @@ export default function VaultPage() {
                       usdValue={redeemValue}
                       balance={tokenBalance}
                     />
+                  </div>
+                  <div className="space-y-1 text-sm">
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Exchange rate</span>
+                      <span className="text-right">{`1 MNV = $${price.toFixed(2)}`}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Redemption fee</span>
+                      <span className="text-right">0.5%</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Receive by</span>
+                      <span className="text-right">
+                        {new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toLocaleString()}
+                      </span>
+                    </div>
                   </div>
                   <Button type="submit" className="w-full">
                     Redeem


### PR DESCRIPTION
## Summary
- display exchange rate and fee information in the vault stake form
- display exchange rate, redemption fee, and estimated receive date in the redeem form

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685038b0c7f48328a69df2fde89c149b