### PR TITLE
Add How Nest Works card

### DIFF
--- a/src/app/vault/page.tsx
+++ b/src/app/vault/page.tsx
@@ -180,6 +180,32 @@ export default function VaultPage() {
 
         <Card>
           <CardHeader>
+            <CardTitle>How Nest Works</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ol className="relative border-l border-border pl-6 space-y-6 text-sm">
+              <li className="relative pl-3">
+                <span className="absolute -left-6 top-0 flex size-6 items-center justify-center rounded-full bg-muted text-foreground text-xs font-medium">1</span>
+                Stake pUSD
+              </li>
+              <li className="relative pl-3">
+                <span className="absolute -left-6 top-0 flex size-6 items-center justify-center rounded-full bg-muted text-foreground text-xs font-medium">2</span>
+                Receive a vault token representing your position
+              </li>
+              <li className="relative pl-3">
+                <span className="absolute -left-6 top-0 flex size-6 items-center justify-center rounded-full bg-muted text-foreground text-xs font-medium">3</span>
+                Your token passively accrues yield over time
+              </li>
+              <li className="relative pl-3">
+                <span className="absolute -left-6 top-0 flex size-6 items-center justify-center rounded-full bg-muted text-foreground text-xs font-medium">4</span>
+                Redeem anytime to claim principal plus yield
+              </li>
+            </ol>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
             <CardTitle>Transparency</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3 text-sm">


### PR DESCRIPTION
## Summary
- extend Mineral Vault page with a "How Nest Works" explainer card

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68503e8a1e688328a065d066bae93f68