### PR TITLE
Add wallet connection mock and global nav

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { WalletProvider } from "@/components/wallet-context";
+import { TopNav } from "@/components/top-nav";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -14,7 +16,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="antialiased font-sans">
-        {children}
+        <WalletProvider>
+          <TopNav />
+          {children}
+        </WalletProvider>
       </body>
     </html>
   );

--- a/src/app/vault/page.tsx
+++ b/src/app/vault/page.tsx
@@ -23,6 +23,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { TokenInput } from "@/components/token-input";
 import { Label } from "@/components/ui/label";
+import { useWallet } from "@/components/wallet-context";
 import {
   AreaChart as RechartsAreaChart,
   Area,
@@ -60,6 +61,7 @@ const tokenholders = [
 ].sort((a, b) => b.balance - a.balance);
 
 export default function VaultPage() {
+  const { connected } = useWallet();
   const [tokenBalance, setTokenBalance] = useState(0);
   const [dollarBalance, setDollarBalance] = useState(0);
   const [pusdBalance, setPusdBalance] = useState(1000);
@@ -349,6 +351,7 @@ export default function VaultPage() {
                       usdValue={stakeValue}
                       balance={pusdBalance}
                       onMax={() => setStakeAmount(pusdBalance.toString())}
+                      disabled={!connected}
                     />
                   </div>
                   <div className="space-y-2">
@@ -360,6 +363,7 @@ export default function VaultPage() {
                       value={stakeAmount ? stakeReceive.toFixed(2) : ""}
                       token="MNV"
                       usdValue={stakeValue}
+                      disabled={!connected}
                     />
                   </div>
                   <div className="space-y-1 text-sm">
@@ -376,7 +380,7 @@ export default function VaultPage() {
                       <span className="text-right">10 day cooldown</span>
                     </div>
                   </div>
-                  <Button type="submit" className="w-full">
+                  <Button type="submit" className="w-full" disabled={!connected}>
                     Stake
                   </Button>
                 </form>
@@ -396,6 +400,7 @@ export default function VaultPage() {
                       onMax={() =>
                         setRedeemAmount((tokenBalance * price).toString())
                       }
+                      disabled={!connected}
                     />
                   </div>
                   <div className="space-y-2">
@@ -408,6 +413,7 @@ export default function VaultPage() {
                       token="MNV"
                       usdValue={redeemValue}
                       balance={tokenBalance}
+                      disabled={!connected}
                     />
                   </div>
                   <div className="space-y-1 text-sm">
@@ -426,7 +432,7 @@ export default function VaultPage() {
                       </span>
                     </div>
                   </div>
-                  <Button type="submit" className="w-full">
+                  <Button type="submit" className="w-full" disabled={!connected}>
                     Redeem
                   </Button>
                 </form>

--- a/src/components/token-input.tsx
+++ b/src/components/token-input.tsx
@@ -11,13 +11,14 @@ interface TokenInputProps extends React.ComponentProps<"input"> {
 }
 
 const TokenInput = React.forwardRef<HTMLInputElement, TokenInputProps>(
-  ({ token, usdValue, balance, onMax, className, readOnly, ...props }, ref) => {
+  ({ token, usdValue, balance, onMax, className, readOnly, disabled, ...props }, ref) => {
     return (
       <div className="grid gap-1">
         <div className="relative">
           <Input
             ref={ref}
             readOnly={readOnly}
+            disabled={disabled}
             className={cn("pr-16", className, readOnly && "cursor-default")}
             {...props}
           />
@@ -37,6 +38,7 @@ const TokenInput = React.forwardRef<HTMLInputElement, TokenInputProps>(
                   variant="ghost"
                   onClick={onMax}
                   className="px-1 h-5 text-[10px]"
+                  disabled={disabled}
                 >
                   MAX
                 </Button>

--- a/src/components/top-nav.tsx
+++ b/src/components/top-nav.tsx
@@ -1,0 +1,20 @@
+"use client";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { useWallet } from "@/components/wallet-context";
+
+export function TopNav() {
+  const { connected, connect, disconnect } = useWallet();
+  return (
+    <nav className="border-b px-6 py-4 flex justify-between items-center">
+      <Link href="/" className="font-bold text-lg">
+        Nest
+      </Link>
+      {connected ? (
+        <Button onClick={disconnect}>Disconnect</Button>
+      ) : (
+        <Button onClick={connect}>Connect</Button>
+      )}
+    </nav>
+  );
+}

--- a/src/components/wallet-context.tsx
+++ b/src/components/wallet-context.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { createContext, useContext, useState } from "react";
+
+interface WalletContextValue {
+  connected: boolean;
+  balance: number;
+  transactions: string[];
+  connect: () => void;
+  disconnect: () => void;
+}
+
+const WalletContext = createContext<WalletContextValue | undefined>(undefined);
+
+export function WalletProvider({ children }: { children: React.ReactNode }) {
+  const [connected, setConnected] = useState(false);
+  const [balance, setBalance] = useState(0);
+  const [transactions, setTransactions] = useState<string[]>([]);
+
+  function connect() {
+    setConnected(true);
+    setBalance(1000);
+    setTransactions(["Initial deposit"]);
+  }
+
+  function disconnect() {
+    setConnected(false);
+    setBalance(0);
+    setTransactions([]);
+  }
+
+  return (
+    <WalletContext.Provider
+      value={{ connected, balance, transactions, connect, disconnect }}
+    >
+      {children}
+    </WalletContext.Provider>
+  );
+}
+
+export function useWallet() {
+  const ctx = useContext(WalletContext);
+  if (!ctx) throw new Error("useWallet must be used within WalletProvider");
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- implement WalletProvider context for mock connection
- add TopNav with Connect/Disconnect actions
- wire provider and nav in root layout
- disable vault staking and redemption when disconnected
- support disabling inputs in TokenInput component

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685058d04614832890d7a3760f8bb112