### PR TITLE
Apply modern design tweaks

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,9 +1,9 @@
 @import "tailwindcss";
 @import "tw-animate-css";
-@import url("https://unpkg.com/@geist/font/stylesheet.css");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap");
 
 :root {
-  --font-geist-sans: "Geist", sans-serif;
+  --font-geist-sans: "Inter", sans-serif;
   --font-geist-mono: "Geist Mono", monospace;
 }
 
@@ -51,71 +51,71 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --background: oklch(0.98 0.02 240);
+  --foreground: oklch(0.25 0.02 240);
+  --card: oklch(1 0 240);
+  --card-foreground: oklch(0.25 0.02 240);
+  --popover: oklch(1 0 240);
+  --popover-foreground: oklch(0.25 0.02 240);
+  --primary: oklch(0.62 0.1 240);
+  --primary-foreground: oklch(0.98 0.02 240);
+  --secondary: oklch(0.95 0.01 240);
+  --secondary-foreground: oklch(0.28 0.02 240);
+  --muted: oklch(0.95 0.01 240);
+  --muted-foreground: oklch(0.45 0.02 240);
+  --accent: oklch(0.94 0.02 240);
+  --accent-foreground: oklch(0.28 0.02 240);
+  --destructive: oklch(0.6 0.15 30);
+  --border: oklch(0.9 0.01 240);
+  --input: oklch(0.9 0.01 240);
+  --ring: oklch(0.7 0.02 240);
+  --chart-1: oklch(0.65 0.12 250);
+  --chart-2: oklch(0.55 0.1 230);
+  --chart-3: oklch(0.45 0.08 210);
+  --chart-4: oklch(0.75 0.12 200);
+  --chart-5: oklch(0.7 0.1 180);
+  --sidebar: oklch(0.97 0.02 240);
+  --sidebar-foreground: oklch(0.28 0.02 240);
+  --sidebar-primary: oklch(0.62 0.1 240);
+  --sidebar-primary-foreground: oklch(0.98 0.02 240);
+  --sidebar-accent: oklch(0.94 0.02 240);
+  --sidebar-accent-foreground: oklch(0.28 0.02 240);
+  --sidebar-border: oklch(0.9 0.01 240);
+  --sidebar-ring: oklch(0.7 0.02 240);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: oklch(0.2 0.02 240);
+  --foreground: oklch(0.98 0.02 240);
+  --card: oklch(0.25 0.02 240);
+  --card-foreground: oklch(0.98 0.02 240);
+  --popover: oklch(0.25 0.02 240);
+  --popover-foreground: oklch(0.98 0.02 240);
+  --primary: oklch(0.85 0.05 240);
+  --primary-foreground: oklch(0.2 0.02 240);
+  --secondary: oklch(0.3 0.02 240);
+  --secondary-foreground: oklch(0.98 0.02 240);
+  --muted: oklch(0.3 0.02 240);
+  --muted-foreground: oklch(0.7 0.02 240);
+  --accent: oklch(0.3 0.02 240);
+  --accent-foreground: oklch(0.98 0.02 240);
+  --destructive: oklch(0.7 0.15 30);
+  --border: oklch(1 0 240 / 15%);
+  --input: oklch(1 0 240 / 20%);
+  --ring: oklch(0.6 0.02 240);
+  --chart-1: oklch(0.6 0.12 250);
+  --chart-2: oklch(0.65 0.1 230);
+  --chart-3: oklch(0.75 0.1 210);
+  --chart-4: oklch(0.7 0.12 200);
+  --chart-5: oklch(0.65 0.1 180);
+  --sidebar: oklch(0.25 0.02 240);
+  --sidebar-foreground: oklch(0.98 0.02 240);
+  --sidebar-primary: oklch(0.6 0.1 240);
+  --sidebar-primary-foreground: oklch(0.98 0.02 240);
+  --sidebar-accent: oklch(0.3 0.02 240);
+  --sidebar-accent-foreground: oklch(0.98 0.02 240);
+  --sidebar-border: oklch(1 0 240 / 15%);
+  --sidebar-ring: oklch(0.6 0.02 240);
 }
 
 @layer base {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-12 pb-24 gap-20 sm:p-24 max-w-4xl mx-auto font-[family-name:var(--font-geist-sans)]">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
         <Image
           className="dark:invert"

--- a/src/app/vault/page.tsx
+++ b/src/app/vault/page.tsx
@@ -255,7 +255,7 @@ export default function VaultPage() {
   }
 
   return (
-    <div className="p-6 md:p-10 grid md:grid-cols-[1fr_320px] gap-6 max-w-5xl mx-auto">
+    <div className="p-8 md:p-12 grid md:grid-cols-[1fr_320px] gap-8 max-w-6xl mx-auto">
       <div className="flex flex-col gap-6">
         <div className="space-y-2">
           <h1 className="text-2xl font-bold">Mineral Vault (MNV)</h1>

--- a/src/components/top-nav.tsx
+++ b/src/components/top-nav.tsx
@@ -20,7 +20,7 @@ export function TopNav() {
   const { connected, connect, disconnect } = useWallet();
   const { theme, toggleTheme } = useTheme();
   return (
-    <nav className="border-b px-6 py-4 flex justify-between items-center">
+    <nav className="border-b px-8 py-6 flex justify-between items-center">
       <Link href="/" className="font-bold text-lg">
         Nest
       </Link>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-4 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className


### PR DESCRIPTION
## Summary
- swap Geist font for Inter
- update color palette to cooler blues and grays
- add airier input padding
- enlarge navigation and layout spacing

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850965cdedc83288171bd26c20b0e20