### PR TITLE
Add Underwriter Info to mineral page

### DIFF
--- a/src/app/mineral/page.tsx
+++ b/src/app/mineral/page.tsx
@@ -809,6 +809,23 @@ export default function VaultPage() {
 
             <Card>
               <CardHeader>
+                <CardTitle>Underwriter Info</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p>
+                  Cicada is a third-party credit intelligence firm specializing
+                  in private credit and real-world asset underwriting. They
+                  provide institutional-grade risk analysis tailored to onchain
+                  finance.
+                </p>
+                <Button variant="link" className="px-0 text-muted-foreground">
+                  View Methodology
+                </Button>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
                 <CardTitle>Transparency</CardTitle>
               </CardHeader>
               <CardContent className="space-y-3 text-sm">


### PR DESCRIPTION
## Summary
- add an Underwriter Info card on the Mineral risk tab

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68514ca3921483288aedd7b5b3278ae9