### PR TITLE
Use Matter and Chivo Mono fonts

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,10 +1,10 @@
 @import "tailwindcss";
 @import "tw-animate-css";
-@import url("https://unpkg.com/@geist/font/stylesheet.css");
+/* Local fonts are loaded in layout.tsx */
 
 :root {
-  --font-geist-sans: "Geist", sans-serif;
-  --font-geist-mono: "Geist Mono", monospace;
+  --font-matter: "Matter", sans-serif;
+  --font-chivo-mono: "Chivo Mono", monospace;
 }
 
 @custom-variant dark (&:is(.dark *));
@@ -12,8 +12,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-matter);
+  --font-mono: var(--font-chivo-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -121,6 +121,7 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+    letter-spacing: -0.02em;
   }
   body {
     @apply bg-white text-foreground;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,24 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import localFont from "next/font/local";
+
+const matter = localFont({
+  src: [
+    { path: "../../public/fonts/matter/Matter-Regular.otf", weight: "400", style: "normal" },
+    { path: "../../public/fonts/matter/Matter-Medium.otf", weight: "500", style: "normal" },
+  ],
+  variable: "--font-matter",
+  display: "swap",
+});
+
+const chivoMono = localFont({
+  src: [
+    { path: "../../public/fonts/chivo-mono/ChivoMono-Regular.ttf", weight: "400", style: "normal" },
+    { path: "../../public/fonts/chivo-mono/ChivoMono-Medium.ttf", weight: "500", style: "normal" },
+  ],
+  variable: "--font-chivo-mono",
+  display: "swap",
+});
 import { WalletProvider } from "@/components/wallet-context";
 import { TopNav } from "@/components/top-nav";
 import { ThemeProvider } from "@/components/theme-context";
@@ -16,7 +35,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${matter.variable} ${chivoMono.variable}`}> 
       <body className="antialiased font-sans">
         <ThemeProvider>
           <WalletProvider>

--- a/src/app/mineral/page.tsx
+++ b/src/app/mineral/page.tsx
@@ -499,7 +499,7 @@ export default function VaultPage() {
               </BreadcrumbItem>
             </BreadcrumbList>
           </Breadcrumb>
-          <h1 className="text-2xl font-bold">Mineral Vault (MNV)</h1>
+          <h1 className="text-2xl font-medium">Mineral Vault (MNV)</h1>
           <p className="text-muted-foreground">
             Tokenized exposure to royalty fees from U.S. mineral and oil extraction.
           </p>
@@ -517,7 +517,7 @@ export default function VaultPage() {
           <div className="flex flex-col sm:flex-row gap-6 my-4">
             <div className="space-y-1">
               <div className="text-xs text-muted-foreground">TVL</div>
-              <div className="text-3xl font-bold">{`$${tvl.toLocaleString()}M`}</div>
+              <div className="text-3xl font-medium">{`$${tvl.toLocaleString()}M`}</div>
               <div
                 className={`text-sm ${
                   tvlDelta >= 0 ? "text-green-500" : "text-muted-foreground"
@@ -528,7 +528,7 @@ export default function VaultPage() {
             </div>
             <div className="space-y-1">
               <div className="text-xs text-muted-foreground">Price</div>
-              <div className="text-3xl font-bold">{`$${price.toFixed(2)}`}</div>
+              <div className="text-3xl font-medium">{`$${price.toFixed(2)}`}</div>
               <div
                 className={`text-sm ${
                   priceDelta >= 0 ? "text-green-500" : "text-muted-foreground"
@@ -539,7 +539,7 @@ export default function VaultPage() {
             </div>
             <div className="space-y-1">
               <div className="text-xs text-muted-foreground">APY</div>
-              <div className="text-3xl font-bold">{currentApy}%</div>
+              <div className="text-3xl font-medium">{currentApy}%</div>
               <div
                 className={`text-sm ${
                   apyDelta >= 0 ? "text-green-500" : "text-muted-foreground"
@@ -572,7 +572,7 @@ export default function VaultPage() {
                   <CardTitle>Balance</CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-2">
-                  <div className="flex items-center gap-2 text-2xl font-bold">
+                  <div className="flex items-center gap-2 text-2xl font-medium">
                     {"$" + dollarBalance.toFixed(2)}
                     <span className="animate-pulse rounded-full bg-green-500 size-2" />
                   </div>
@@ -724,7 +724,7 @@ export default function VaultPage() {
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="space-y-1">
-                  <div className="text-3xl font-bold">{`$${tvl.toLocaleString()}M`}</div>
+                  <div className="text-3xl font-medium">{`$${tvl.toLocaleString()}M`}</div>
                   <div
                     className={`text-sm ${
                       tvlDelta >= 0 ? "text-green-500" : "text-muted-foreground"
@@ -762,7 +762,7 @@ export default function VaultPage() {
                   </TabsList>
                   <TabsContent value="apy" className="space-y-4">
                     <div className="space-y-1">
-                      <div className="text-3xl font-bold">{currentApy}%</div>
+                      <div className="text-3xl font-medium">{currentApy}%</div>
                       <div
                         className={`text-sm ${
                           apyDelta >= 0 ? "text-green-500" : "text-muted-foreground"
@@ -804,7 +804,7 @@ export default function VaultPage() {
                   </TabsContent>
                   <TabsContent value="price" className="space-y-4">
                     <div className="space-y-1">
-                      <div className="text-3xl font-bold">{`$${price.toFixed(2)}`}</div>
+                      <div className="text-3xl font-medium">{`$${price.toFixed(2)}`}</div>
                       <div
                         className={`text-sm ${
                           priceDelta >= 0 ? "text-green-500" : "text-muted-foreground"
@@ -882,7 +882,7 @@ export default function VaultPage() {
                       </TooltipTrigger>
                       <TooltipContent>Low is safer, high is riskier.</TooltipContent>
                     </Tooltip>
-                    <div className="flex items-center gap-1 font-semibold">
+                    <div className="flex items-center gap-1 font-medium">
                       <span
                         className={`size-2 rounded-full ${riskSummary.level === "Low" ? "bg-green-500" : riskSummary.level === "Moderate" ? "bg-yellow-500" : "bg-red-500"}`}
                       />
@@ -896,7 +896,7 @@ export default function VaultPage() {
                       </TooltipTrigger>
                       <TooltipContent>Independent score from Cicada Partners. 1 is riskiest, 5 is safest.</TooltipContent>
                     </Tooltip>
-                    <div className="font-semibold">{riskSummary.cicadaScore}/5</div>
+                    <div className="font-medium">{riskSummary.cicadaScore}/5</div>
                   </div>
                   <div className="space-y-1">
                     <Tooltip>
@@ -905,7 +905,7 @@ export default function VaultPage() {
                       </TooltipTrigger>
                       <TooltipContent>Approximate placement on Moody&apos;s corporate rating scale.</TooltipContent>
                     </Tooltip>
-                    <div className="font-semibold">{riskSummary.moodys}</div>
+                    <div className="font-medium">{riskSummary.moodys}</div>
                   </div>
                 </div>
                 <p>{riskSummary.narrative}</p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -64,7 +64,7 @@ export default function Home() {
 
       {/* metrics strip removed */}
       <section className="space-y-4">
-        <h2 className="text-xl font-bold">Nest TVL</h2>
+        <h2 className="text-xl font-medium">Nest TVL</h2>
         <div className="bg-[#D9DFCF] rounded-[24px] p-6">
           <div className="space-y-[12px]">
             <div className="text-[60px] leading-[72px] font-medium text-[#030301]">
@@ -103,7 +103,7 @@ export default function Home() {
       </section>
 
       <section className="space-y-4">
-        <h2 className="text-xl font-bold">Compositions</h2>
+        <h2 className="text-xl font-medium">Compositions</h2>
         <p className="max-w-[50%] text-muted-foreground">
           Stake into institutional-grade, professional curated real-world asset strategies through a single onchain token. Each vault follows a clear strategy—balancing risk, yield, and liquidity—so you get diversified exposure without managing individual assets.
         </p>
@@ -132,7 +132,7 @@ export default function Home() {
 
 
       <section className="space-y-4">
-        <h2 className="text-xl font-bold">Single Assets</h2>
+        <h2 className="text-xl font-medium">Single Assets</h2>
         <p className="max-w-[50%] text-muted-foreground">
           Stake directly into real-world, yield-generating assets—one vault, one token. It’s the simplest way to access onchain yield.
         </p>

--- a/src/components/top-nav.tsx
+++ b/src/components/top-nav.tsx
@@ -21,7 +21,7 @@ export function TopNav() {
   const { theme, toggleTheme } = useTheme();
   return (
     <nav className="border-b px-6 py-4 flex justify-between items-center">
-      <Link href="/" className="font-bold text-lg">
+      <Link href="/" className="font-medium text-lg">
         Nest
       </Link>
       {connected ? (

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -32,7 +32,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      className={cn("leading-none font-medium", className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- use Matter as the primary font and Chivo Mono for numbers
- adjust font weights for titles and labels
- tighten letter spacing

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68527e3cd634832891ce6028a730c93b