### PR TITLE
Update homepage styles

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -182,7 +182,7 @@ export default function Home() {
 
       <section className="space-y-4">
         <h2 className="text-[32px] leading-[40px] font-medium">Compositions</h2>
-        <p className="text-[20px] leading-[28px] font-medium max-w-[640px] text-muted-foreground">
+      <p className="text-[20px] leading-[28px] font-medium max-w-[640px] text-muted-foreground mb-10">
           Stake into institutional-grade, professional curated real-world asset strategies through a single onchain token. Each vault follows a clear strategy—balancing risk, yield, and liquidity—so you get diversified exposure without managing individual assets.
         </p>
         <div className="flex gap-6 pb-4">
@@ -196,7 +196,7 @@ export default function Home() {
 
       <section className="space-y-4">
         <h2 className="text-[32px] leading-[40px] font-medium">Single Assets</h2>
-        <p className="text-[20px] leading-[28px] font-medium max-w-[640px] text-muted-foreground">
+      <p className="text-[20px] leading-[28px] font-medium max-w-[640px] text-muted-foreground mb-10">
           Stake directly into real-world, yield-generating assets—one vault, one token. It’s the simplest way to access onchain yield.
         </p>
         <div className="flex gap-6 pb-4">

--- a/src/components/how-nest-works.tsx
+++ b/src/components/how-nest-works.tsx
@@ -6,8 +6,8 @@ export function HowNestWorksCard() {
   ];
   return (
     <div className="bg-[#F5F5F5] p-8 rounded-[24px]">
-      <h2 className="text-[32px] leading-[40px] font-medium">How Nest Works</h2>
-      <div className="mt-8 grid grid-cols-3 px-8">
+      <h2 className="text-[24px] leading-[32px] font-medium">How Nest Works</h2>
+      <div className="mt-8 grid grid-cols-3 px-8 gap-12">
         {steps.map((text, idx) => (
           <div
             key={idx}


### PR DESCRIPTION
## Summary
- tweak How Nest Works heading and step spacing
- increase margin after subtext in Compositions and Single Assets sections

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852bf9a85d08328a7120c2257c1e223