### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/app/mineral/page.tsx
+++ b/src/app/mineral/page.tsx
@@ -874,7 +874,7 @@ export default function VaultPage() {
                 <CardTitle>Risk Profile</CardTitle>
               </CardHeader>
               <CardContent className="space-y-4 text-sm">
-                <div className="grid grid-cols-3 gap-4">
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
                   <div className="space-y-1">
                     <Tooltip>
                       <TooltipTrigger asChild>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -185,7 +185,7 @@ export default function Home() {
       <p className="text-[20px] leading-[28px] font-medium max-w-[640px] text-muted-foreground mb-10">
           Stake into institutional-grade, professional curated real-world asset strategies through a single onchain token. Each vault follows a clear strategy—balancing risk, yield, and liquidity—so you get diversified exposure without managing individual assets.
         </p>
-        <div className="flex gap-6 pb-4">
+        <div className="grid gap-6 pb-4 sm:grid-cols-2 lg:grid-cols-3">
           {compositions.map((c) => (
             <VaultCard key={c.name} {...c} />
           ))}
@@ -199,11 +199,11 @@ export default function Home() {
       <p className="text-[20px] leading-[28px] font-medium max-w-[640px] text-muted-foreground mb-10">
           Stake directly into real-world, yield-generating assets—one vault, one token. It’s the simplest way to access onchain yield.
         </p>
-        <div className="flex gap-6 pb-4">
+        <div className="grid gap-6 pb-4 sm:grid-cols-2 lg:grid-cols-3">
           {assets.map((a, i) => {
             const card = <VaultCard key={a.name} {...a} />;
             return i === 0 ? (
-              <Link href="/mineral" className="flex-1" key={a.name}>
+              <Link href="/mineral" className="block w-full" key={a.name}>
                 {card}
               </Link>
             ) : (

--- a/src/components/how-nest-works.tsx
+++ b/src/components/how-nest-works.tsx
@@ -5,9 +5,9 @@ export function HowNestWorksCard() {
     "As the assets generate yield, your vault token increases in value.",
   ];
   return (
-    <div className="bg-[#F5F5F5] p-8 rounded-[24px]">
+    <div className="bg-[#F5F5F5] p-6 sm:p-8 rounded-[24px]">
       <h2 className="text-[24px] leading-[32px] font-medium">How Nest Works</h2>
-      <div className="mt-8 grid grid-cols-3 px-8 gap-12">
+      <div className="mt-8 grid grid-cols-1 sm:grid-cols-3 px-4 sm:px-8 gap-6 sm:gap-12">
         {steps.map((text, idx) => (
           <div
             key={idx}

--- a/src/components/top-nav.tsx
+++ b/src/components/top-nav.tsx
@@ -20,7 +20,7 @@ export function TopNav() {
   const { connected, connect, disconnect } = useWallet();
   const { theme, toggleTheme } = useTheme();
   return (
-    <nav className="border-b px-6 flex items-center justify-between h-[72px]">
+    <nav className="border-b px-4 md:px-6 flex items-center justify-between h-16 md:h-[72px]">
       <Link href="/" className="block">
         <img
           src="/nest-logo.svg"

--- a/src/components/vault-card.tsx
+++ b/src/components/vault-card.tsx
@@ -13,7 +13,7 @@ interface VaultCardProps {
 
 export function VaultCard({ icon, name, description, tvl, apy, history }: VaultCardProps) {
   return (
-    <Card className="flex-1 min-w-[16rem] bg-[#F5F5F5] shadow-none border-none py-0">
+    <Card className="flex-1 w-full sm:min-w-[16rem] bg-[#F5F5F5] shadow-none border-none py-0">
       <div className="p-6">
         <div className="flex items-center gap-2">
           <Avatar className="size-8">


### PR DESCRIPTION
## Summary
- tweak navigation layout spacing for small screens
- make `HowNestWorksCard` responsive
- allow `VaultCard` to shrink on small screens
- display vault sections as responsive grids
- update Mineral risk grid for mobile

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853ae4e71fc8328bc0605f172342abc