### PR TITLE
Update vault card layout

### DIFF
--- a/src/components/vault-card.tsx
+++ b/src/components/vault-card.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Bolt } from "lucide-react";
+import { Zap } from "lucide-react";
 
 interface VaultCardProps {
   icon: string;
@@ -24,7 +24,7 @@ export function VaultCard({ icon, name, description, tvl, apy, tokenValue }: Vau
   }, []);
 
   return (
-    <Card className="flex-1 w-full sm:min-w-[16rem] bg-[#F5F5F5] shadow-none border-none py-0">
+    <Card className="flex-1 w-full sm:min-w-[16rem] aspect-square bg-[#F5F5F5] shadow-none border-none py-0 gap-0">
       <div className="p-6">
         <div className="flex items-center gap-2">
           <Avatar className="size-8">
@@ -35,26 +35,28 @@ export function VaultCard({ icon, name, description, tvl, apy, tokenValue }: Vau
         </div>
         <p className="mt-3 text-muted-foreground leading-[24px]">{description}</p>
       </div>
-      <div className="px-6 mt-6">
-        <div className="text-[16px] leading-[24px] text-muted-foreground">Token Value</div>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="mt-1 flex items-center gap-1 text-[20px] leading-[32px] font-semibold">
-              {`$${animatedValue.toFixed(2)}`}
-              <Bolt className="size-4 fill-[#28A29C] stroke-none" />
-            </div>
-          </TooltipTrigger>
-          <TooltipContent sideOffset={4}>Generating real-world yield in real time</TooltipContent>
-        </Tooltip>
-      </div>
-      <div className="grid grid-cols-2 px-6 pt-6 pb-6">
+      <div className="mt-6 px-6 pb-6 flex flex-col space-y-3">
         <div>
-          <div className="text-[16px] leading-[24px] text-muted-foreground">TVL</div>
-          <div className="mt-1 text-[20px] leading-[32px] font-semibold">{`$${tvl}M`}</div>
+          <div className="text-[16px] leading-[24px] text-muted-foreground">Token Value</div>
+          <div className="mt-1 flex items-center gap-1 text-[20px] leading-[32px] font-semibold">
+            {`$${animatedValue.toFixed(2)}`}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Zap className="size-4 fill-[#28A29C] stroke-none" />
+              </TooltipTrigger>
+              <TooltipContent sideOffset={4}>Generating real-world yield in real time</TooltipContent>
+            </Tooltip>
+          </div>
         </div>
-        <div>
-          <div className="text-[16px] leading-[24px] text-muted-foreground">APY</div>
-          <div className="mt-1 text-[20px] leading-[32px] font-semibold">{`${apy}%`}</div>
+        <div className="grid grid-cols-2">
+          <div>
+            <div className="text-[16px] leading-[24px] text-muted-foreground">TVL</div>
+            <div className="mt-1 text-[20px] leading-[32px] font-semibold">{`$${tvl}M`}</div>
+          </div>
+          <div>
+            <div className="text-[16px] leading-[24px] text-muted-foreground">APY</div>
+            <div className="mt-1 text-[20px] leading-[32px] font-semibold">{`${apy}%`}</div>
+          </div>
         </div>
       </div>
     </Card>


### PR DESCRIPTION
## Summary
- tweak vault card layout spacing
- replace Bolt icon with Zap and limit tooltip trigger to the icon
- make card square aspect ratio

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68555386841483288095dc721f6b702c