### PR TITLE
Add partner logo carousel and update vault cards

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,6 +46,12 @@ export default function Home() {
       apy: 12.3,
       tokenValue: 1.12,
       icon: "/tokens/nest-treasuries.svg",
+      partnerLogos: [
+        "/partners/anemoy.svg",
+        "/partners/centrifuge.svg",
+        "/partners/m.svg",
+        "/partners/superstate.svg",
+      ],
     },
     {
       name: "Nest Alpha",
@@ -54,6 +60,13 @@ export default function Home() {
       apy: 9.8,
       tokenValue: 0.98,
       icon: "/tokens/nest-alpha.svg",
+      partnerLogos: [
+        "/partners/superstate.svg",
+        "/partners/midas.svg",
+        "/partners/credbull.svg",
+        "/partners/mineral.svg",
+        "/partners/whinfell.svg",
+      ],
     },
     {
       name: "Nest Credit",
@@ -62,6 +75,14 @@ export default function Home() {
       apy: 8.1,
       tokenValue: 1.05,
       icon: "/tokens/nest-credit.svg",
+      partnerLogos: [
+        "/partners/midas.svg",
+        "/partners/goldfinch.svg",
+        "/partners/anemoy.svg",
+        "/partners/centrifuge.svg",
+        "/partners/m.svg",
+        "/partners/superstate.svg",
+      ],
     },
   ];
 

--- a/src/components/logo-carousel.tsx
+++ b/src/components/logo-carousel.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+
+interface LogoCarouselProps {
+  logos: string[];
+}
+
+export function LogoCarousel({ logos }: LogoCarouselProps) {
+  const [offset, setOffset] = useState(0);
+  const itemWidth = 88; // 80 width + 8 gap
+
+  useEffect(() => {
+    if (logos.length > 3) {
+      const id = setInterval(() => {
+        setOffset((o) => (o + 1) % logos.length);
+      }, 3000);
+      return () => clearInterval(id);
+    }
+  }, [logos.length]);
+
+  const translateX = -(offset * itemWidth);
+
+  const items = logos.length > 3 ? logos.concat(logos) : logos;
+
+  return (
+    <div className="overflow-hidden">
+      <div
+        className="flex items-center gap-2"
+        style={{
+          transform: `translateX(${translateX}px)`,
+          transition: logos.length > 3 ? "transform 0.5s linear" : undefined,
+        }}
+      >
+        {items.map((logo, i) => (
+          <img
+            key={i}
+            src={logo}
+            width={80}
+            height={48}
+            className="shrink-0"
+            alt="partner logo"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/vault-card.tsx
+++ b/src/components/vault-card.tsx
@@ -3,6 +3,7 @@ import { Card } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Zap } from "lucide-react";
+import { LogoCarousel } from "@/components/logo-carousel";
 
 interface VaultCardProps {
   icon: string;
@@ -11,9 +12,18 @@ interface VaultCardProps {
   tvl: number;
   apy: number;
   tokenValue: number;
+  partnerLogos?: string[];
 }
 
-export function VaultCard({ icon, name, description, tvl, apy, tokenValue }: VaultCardProps) {
+export function VaultCard({
+  icon,
+  name,
+  description,
+  tvl,
+  apy,
+  tokenValue,
+  partnerLogos,
+}: VaultCardProps) {
   const [animatedValue, setAnimatedValue] = useState(tokenValue);
 
   useEffect(() => {
@@ -24,7 +34,11 @@ export function VaultCard({ icon, name, description, tvl, apy, tokenValue }: Vau
   }, []);
 
   return (
-    <Card className="flex-1 w-full sm:min-w-[16rem] aspect-square bg-[#F5F5F5] shadow-none border-none py-0 gap-0">
+    <Card
+      className={`flex-1 w-full sm:min-w-[16rem] bg-[#F5F5F5] shadow-none border-none py-0 gap-0 ${
+        partnerLogos ? "" : "aspect-square"
+      }`}
+    >
       <div className="p-6">
         <div className="flex items-center gap-2">
           <Avatar className="size-8">
@@ -35,29 +49,34 @@ export function VaultCard({ icon, name, description, tvl, apy, tokenValue }: Vau
         </div>
         <p className="mt-3 text-muted-foreground leading-[24px]">{description}</p>
       </div>
-      <div className="mt-6 px-6 pb-6 flex flex-col space-y-3">
-        <div>
-          <div className="text-[16px] leading-[24px] text-muted-foreground">Token Value</div>
-          <div className="mt-1 flex items-center gap-1 text-[20px] leading-[32px] font-semibold">
-            {`$${animatedValue.toFixed(2)}`}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Zap className="size-4 fill-[#28A29C] stroke-none" />
-              </TooltipTrigger>
-              <TooltipContent sideOffset={4}>Generating real-world yield in real time</TooltipContent>
-            </Tooltip>
-          </div>
-        </div>
-        <div className="grid grid-cols-2">
+      <div
+        className={`px-6 pb-6 flex flex-col ${
+          partnerLogos ? "gap-6 mt-[64px]" : "space-y-3 mt-6"
+        }`}
+      >
+        <div className="flex justify-between">
           <div>
-            <div className="text-[16px] leading-[24px] text-muted-foreground">TVL</div>
-            <div className="mt-1 text-[20px] leading-[32px] font-semibold">{`$${tvl}M`}</div>
+            <div className="text-[16px] leading-[24px] text-muted-foreground">Price</div>
+            <div className="mt-1 flex items-center gap-1 text-[20px] leading-[32px] font-semibold">
+              {`$${animatedValue.toFixed(2)}`}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Zap className="size-4 fill-[#28A29C] stroke-none" />
+                </TooltipTrigger>
+                <TooltipContent sideOffset={4}>Generating real-world yield in real time</TooltipContent>
+              </Tooltip>
+            </div>
           </div>
           <div>
             <div className="text-[16px] leading-[24px] text-muted-foreground">APY</div>
             <div className="mt-1 text-[20px] leading-[32px] font-semibold">{`${apy}%`}</div>
           </div>
+          <div>
+            <div className="text-[16px] leading-[24px] text-muted-foreground">TVL</div>
+            <div className="mt-1 text-[20px] leading-[32px] font-semibold">{`$${tvl}M`}</div>
+          </div>
         </div>
+        {partnerLogos && <LogoCarousel logos={partnerLogos} />}
       </div>
     </Card>
   );


### PR DESCRIPTION
## Summary
- update vault cards so Price, APY and TVL appear on one line
- rename **Token Value** label to **Price**
- support partner logos with new `LogoCarousel` component
- change composition cards to use variable height and add logo carousel

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685559a9b9c483288bfc5b94c5295f39