### PR TITLE
Revamp admin dashboard layout

### DIFF
--- a/src/app/admin/assets/page.tsx
+++ b/src/app/admin/assets/page.tsx
@@ -1,0 +1,232 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuCheckboxItem,
+} from "@/components/ui/dropdown-menu";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  VisibilityState,
+} from "@tanstack/react-table";
+
+interface AssetEntry {
+  name: string;
+  issuer: string;
+  price: number;
+  priceSource: string;
+  amountNest: number;
+  amountUsd: number;
+  estApy: number;
+  currApy: number;
+  apyDiff: number;
+  yieldReceived: number;
+  yieldExpected: number;
+  yieldCycle: string;
+  lastPaid: string;
+  nextPayout: string;
+  jurisdiction: string;
+  legal: string;
+  redemption: string;
+}
+
+const integratedAssets: AssetEntry[] = [
+  {
+    name: "Mineral Vault",
+    issuer: "Mineral",
+    price: 1.23,
+    priceSource: "https://example.com/mineral",
+    amountNest: 50000,
+    amountUsd: 61500,
+    estApy: 8.7,
+    currApy: 8.5,
+    apyDiff: -0.2,
+    yieldReceived: 5000,
+    yieldExpected: 5200,
+    yieldCycle: "Monthly",
+    lastPaid: "2024-06-01",
+    nextPayout: "2024-07-01",
+    jurisdiction: "US",
+    legal: "SPV",
+    redemption: "7 days",
+  },
+  {
+    name: "iSNR",
+    issuer: "Invesco",
+    price: 1.08,
+    priceSource: "https://example.com/isnr",
+    amountNest: 30000,
+    amountUsd: 32400,
+    estApy: 6.0,
+    currApy: 6.1,
+    apyDiff: 0.1,
+    yieldReceived: 2500,
+    yieldExpected: 2400,
+    yieldCycle: "Quarterly",
+    lastPaid: "2024-05-15",
+    nextPayout: "2024-08-15",
+    jurisdiction: "US",
+    legal: "Reg D",
+    redemption: "14 days",
+  },
+];
+
+const pendingAssets: AssetEntry[] = [
+  {
+    name: "mBASIS",
+    issuer: "M DAO",
+    price: 0.92,
+    priceSource: "https://example.com/mbasis",
+    amountNest: 0,
+    amountUsd: 0,
+    estApy: 7.1,
+    currApy: 0,
+    apyDiff: 0,
+    yieldReceived: 0,
+    yieldExpected: 0,
+    yieldCycle: "Monthly",
+    lastPaid: "-",
+    nextPayout: "-",
+    jurisdiction: "SG",
+    legal: "DAO",
+    redemption: "-",
+  },
+];
+
+export default function AssetsPage() {
+  const [view, setView] = useState("integrated");
+  const data = view === "integrated" ? integratedAssets : pendingAssets;
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+
+  const columns: ColumnDef<AssetEntry>[] = [
+    { accessorKey: "name", header: "Asset name" },
+    { accessorKey: "issuer", header: "Issuer name" },
+    {
+      accessorKey: "price",
+      header: "Asset price",
+      cell: ({ row }) => `$${row.getValue<number>("price").toFixed(2)}`,
+    },
+    {
+      accessorKey: "priceSource",
+      header: "Price source (URL)",
+      cell: ({ row }) => (
+        <Link href={row.getValue<string>("priceSource")}>{"Source"}</Link>
+      ),
+    },
+    { accessorKey: "amountNest", header: "Amount on Nest" },
+    { accessorKey: "amountUsd", header: "Amount in USD" },
+    {
+      accessorKey: "estApy",
+      header: "Estimated APY",
+      cell: ({ row }) => `${row.getValue<number>("estApy")}%`,
+    },
+    {
+      accessorKey: "currApy",
+      header: "Current APY",
+      cell: ({ row }) => `${row.getValue<number>("currApy")}%`,
+    },
+    {
+      accessorKey: "apyDiff",
+      header: "APY Difference",
+      cell: ({ row }) => `${row.getValue<number>("apyDiff")}%`,
+    },
+    { accessorKey: "yieldReceived", header: "Yield Received 30D" },
+    { accessorKey: "yieldExpected", header: "Yield Expected 30D" },
+    { accessorKey: "yieldCycle", header: "Yield Payout Cycle" },
+    { accessorKey: "lastPaid", header: "Last Paid" },
+    { accessorKey: "nextPayout", header: "Next Payout Date" },
+    { accessorKey: "jurisdiction", header: "Jurisdiction" },
+    { accessorKey: "legal", header: "Legal Structure" },
+    { accessorKey: "redemption", header: "Redemption Duration" },
+  ];
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { columnVisibility },
+    onColumnVisibilityChange: setColumnVisibility,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <div className="p-6 md:p-10 space-y-8">
+      <Tabs value={view} onValueChange={setView} className="w-full space-y-4">
+        <TabsList>
+          <TabsTrigger value="integrated">Integrated</TabsTrigger>
+          <TabsTrigger value="pending">To integrate</TabsTrigger>
+        </TabsList>
+        <TabsContent value={view}>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <CardTitle>Assets</CardTitle>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline">Columns</Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  {table.getAllLeafColumns().map((column) => {
+                    const label = column.columnDef.header as string;
+                    return (
+                      <DropdownMenuCheckboxItem
+                        key={column.id}
+                        checked={column.getIsVisible()}
+                        onCheckedChange={column.toggleVisibility}
+                      >
+                        {label}
+                      </DropdownMenuCheckboxItem>
+                    );
+                  })}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </CardHeader>
+            <CardContent className="p-0">
+              <Table>
+                <TableHeader className="bg-muted">
+                  {table.getHeaderGroups().map((hg) => (
+                    <TableRow key={hg.id} className="border-muted">
+                      {hg.headers.map((header) => (
+                        <TableHead key={header.id}>
+                          {flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                        </TableHead>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableHeader>
+                <TableBody>
+                  {table.getRowModel().rows.map((row) => (
+                    <TableRow key={row.id} className="border-muted">
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id} className="whitespace-nowrap">
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/app/admin/compositions/page.tsx
+++ b/src/app/admin/compositions/page.tsx
@@ -1,0 +1,7 @@
+export default function CompositionsPage() {
+  return (
+    <div className="p-6 md:p-10">
+      <p>Compositions page coming soon.</p>
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,37 @@
+"use client";
+import { Sidebar, SidebarContent, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem, SidebarProvider } from "@/components/ui/sidebar";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  return (
+    <SidebarProvider>
+      <div className="flex h-[calc(100svh-4rem)] md:h-[calc(100svh-72px)]">
+        <Sidebar className="border-r" collapsible="offcanvas">
+          <SidebarHeader className="text-lg font-medium px-2 py-3">Admin</SidebarHeader>
+          <SidebarContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton asChild isActive={pathname === "/admin"}>
+                  <Link href="/admin">Overview</Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton asChild isActive={pathname.startsWith("/admin/assets")}> 
+                  <Link href="/admin/assets">Assets</Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton asChild isActive={pathname.startsWith("/admin/compositions")}> 
+                  <Link href="/admin/compositions">Compositions</Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarContent>
+        </Sidebar>
+        <main className="flex-1 overflow-y-auto">{children}</main>
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { formatDistanceToNow, differenceInDays, parseISO } from "date-fns";
 import { Button } from "@/components/ui/button";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Card,
   CardContent,
@@ -19,20 +15,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
-  ColumnDef,
-  flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
-  useReactTable,
-  type SortingState,
-} from "@tanstack/react-table";
+
 import {
   LineChart as RechartsLineChart,
   Line,
@@ -72,69 +55,6 @@ const secondaryKpis: KPI[] = [
   { title: "Avg. Redemption Duration", value: "2 days" },
 ];
 
-interface Vault {
-  icon: string;
-  name: string;
-  type: "Asset" | "Composition";
-  curator: string;
-  price: number;
-  tvl: number;
-  apy: number;
-  drift: number;
-  rebalance: string;
-  pending: number;
-}
-
-const vaults: Vault[] = [
-  {
-    icon: "/tokens/mineral-vault.svg",
-    name: "Mineral Vault",
-    type: "Asset",
-    curator: "Nest",
-    price: 1.23,
-    tvl: 5.0,
-    apy: 8.7,
-    drift: 0.1,
-    rebalance: "2025-06-15",
-    pending: 10000,
-  },
-  {
-    icon: "/tokens/nest-treasuries.svg",
-    name: "Nest Treasuries",
-    type: "Composition",
-    curator: "Nest",
-    price: 1.12,
-    tvl: 3.2,
-    apy: 12.3,
-    drift: -0.05,
-    rebalance: "2025-06-18",
-    pending: 5000,
-  },
-  {
-    icon: "/tokens/nest-alpha.svg",
-    name: "Nest Alpha",
-    type: "Composition",
-    curator: "Nest",
-    price: 0.98,
-    tvl: 2.4,
-    apy: 9.8,
-    drift: 0.02,
-    rebalance: "2025-06-12",
-    pending: 1200,
-  },
-  {
-    icon: "/tokens/nest-credit.svg",
-    name: "Nest Credit",
-    type: "Composition",
-    curator: "Nest",
-    price: 1.05,
-    tvl: 2.8,
-    apy: 8.1,
-    drift: -0.03,
-    rebalance: "2025-06-08",
-    pending: 7500,
-  },
-];
 
 interface ActivityLog {
   timestamp: string;
@@ -171,99 +91,34 @@ const activityLogs: ActivityLog[] = [
   },
 ];
 
+interface InboxItem {
+  date: string;
+  description: string;
+  action: string;
+}
+
+const inboxItems: InboxItem[] = [
+  {
+    date: "2024-06-10",
+    description: "Approve iSNR integration",
+    action: "Review",
+  },
+  {
+    date: "2024-06-12",
+    description: "Check redemption request for Mineral Vault",
+    action: "View",
+  },
+  {
+    date: "2024-06-15",
+    description: "Update yield numbers for Nest Alpha",
+    action: "Update",
+  },
+];
+
 export default function AdminPage() {
-  const [filter, setFilter] = useState<"All" | "Asset" | "Composition">("All");
-  const [sorting, setSorting] = useState<SortingState>([]);
-
-  const data = useMemo(() => {
-    return vaults.filter((v) => (filter === "All" ? true : v.type === filter));
-  }, [filter]);
-
-  const headerWithTooltip = (label: string, tip: string) => (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span>{label}</span>
-      </TooltipTrigger>
-      <TooltipContent sideOffset={4}>{tip}</TooltipContent>
-    </Tooltip>
-  );
-
-  const columns: ColumnDef<Vault>[] = [
-    {
-      accessorKey: "name",
-      header: () => headerWithTooltip("Vault Name", "Name of the vault"),
-      cell: ({ row }) => (
-        <div className="flex items-center gap-2">
-          <Avatar className="size-6">
-            <AvatarImage src={row.original.icon} alt="" />
-            <AvatarFallback>{row.getValue<string>("name").charAt(0)}</AvatarFallback>
-          </Avatar>
-          {row.getValue<string>("name")}
-        </div>
-      ),
-    },
-    {
-      accessorKey: "type",
-      header: () => headerWithTooltip("Type", "Vault type"),
-    },
-    {
-      accessorKey: "curator",
-      header: () => headerWithTooltip("Curator", "Vault manager"),
-    },
-    {
-      accessorKey: "price",
-      header: () => headerWithTooltip("Token Price", "Price per vault token"),
-      cell: ({ row }) => `$${row.getValue<number>("price").toFixed(2)}`,
-    },
-    {
-      accessorKey: "tvl",
-      header: () => headerWithTooltip("TVL", "Total value locked"),
-      cell: ({ row }) => `$${row.getValue<number>("tvl").toLocaleString()}M`,
-    },
-    {
-      accessorKey: "apy",
-      header: () => headerWithTooltip("APY", "Annual percentage yield"),
-      cell: ({ row }) => `${row.getValue<number>("apy")}%`,
-    },
-    {
-      accessorKey: "drift",
-      header: () => headerWithTooltip("Drift", "Backing vs token price"),
-      cell: ({ row }) => `${(Math.abs(row.getValue<number>("drift")) * 100).toFixed(1)}%`,
-    },
-    {
-      accessorKey: "rebalance",
-      header: () => headerWithTooltip("Last Rebalance", "When vault was rebalanced"),
-      cell: ({ row }) => {
-        const date = parseISO(row.getValue<string>("rebalance"));
-        const diff = formatDistanceToNow(date, { addSuffix: true });
-        const stale = differenceInDays(Date.now(), date) > 10;
-        return (
-          <div className="flex items-center gap-1">
-            {diff}
-            {stale && <span className="size-2 rounded-full bg-yellow-400" />}
-          </div>
-        );
-      },
-    },
-    {
-      accessorKey: "pending",
-      header: () => headerWithTooltip("Pending Redemptions", "Pending withdrawals"),
-      cell: ({ row }) =>
-        `${row.getValue<number>("pending").toLocaleString()} pUSD`,
-    },
-  ];
-
-  const table = useReactTable({
-    data,
-    columns,
-    state: { sorting },
-    onSortingChange: setSorting,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-  });
 
   return (
-    <div className="p-6 md:p-10 space-y-8 max-w-[1080px] mx-auto">
+    <div className="p-6 md:p-10 space-y-8">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-medium">Welcome to the Nest Console</h1>
         <Button>New Vault</Button>
@@ -354,51 +209,24 @@ export default function AdminPage() {
       </div>
 
       <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>Vaults</CardTitle>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" className="capitalize">
-                {filter.toLowerCase()}
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {(["All", "Asset", "Composition"] as const).map((type) => (
-                <DropdownMenuItem key={type} onClick={() => setFilter(type)}>
-                  {type}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+        <CardHeader>
+          <CardTitle>Inbox</CardTitle>
         </CardHeader>
         <CardContent className="p-0">
           <Table>
             <TableHeader className="bg-muted">
-              {table.getHeaderGroups().map((headerGroup) => (
-                <TableRow key={headerGroup.id} className="border-muted">
-                  {headerGroup.headers.map((header) => (
-                    <TableHead
-                      key={header.id}
-                      onClick={header.column.getToggleSortingHandler()}
-                      className="cursor-pointer select-none"
-                    >
-                      {flexRender(
-                        header.column.columnDef.header,
-                        header.getContext()
-                      )}
-                    </TableHead>
-                  ))}
-                </TableRow>
-              ))}
+              <TableRow className="border-muted">
+                <TableHead>Date</TableHead>
+                <TableHead>Description</TableHead>
+                <TableHead>Action</TableHead>
+              </TableRow>
             </TableHeader>
             <TableBody>
-              {table.getRowModel().rows.map((row) => (
-                <TableRow key={row.id} className="border-muted">
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id} className="whitespace-nowrap">
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </TableCell>
-                  ))}
+              {inboxItems.map((item, i) => (
+                <TableRow key={i} className="border-muted">
+                  <TableCell>{item.date}</TableCell>
+                  <TableCell>{item.description}</TableCell>
+                  <TableCell>{item.action}</TableCell>
                 </TableRow>
               ))}
             </TableBody>


### PR DESCRIPTION
## Summary
- add dedicated admin layout with sidebar links
- replace admin overview page contents with inbox and activity tables
- create admin Assets table with column toggles
- stub compositions page

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6858808523148328b33ff12ea513b58e