### PR TITLE
Improve admin assets table UX

### DIFF
--- a/src/app/admin/assets/page.tsx
+++ b/src/app/admin/assets/page.tsx
@@ -17,13 +17,16 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Input } from "@/components/ui/input";
 import {
   ColumnDef,
   flexRender,
   getCoreRowModel,
+  getSortedRowModel,
   useReactTable,
   VisibilityState,
+  SortingState,
 } from "@tanstack/react-table";
 
 interface AssetEntry {
@@ -111,122 +114,206 @@ const pendingAssets: AssetEntry[] = [
 
 export default function AssetsPage() {
   const [view, setView] = useState("integrated");
-  const data = view === "integrated" ? integratedAssets : pendingAssets;
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  const [integratedData, setIntegratedData] = useState(integratedAssets);
+  const [pendingData, setPendingData] = useState(pendingAssets);
+  const data = view === "integrated" ? integratedData : pendingData;
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
+    priceSource: false,
+    amountUsd: false,
+    yieldReceived: false,
+    yieldExpected: false,
+    lastPaid: false,
+    jurisdiction: false,
+    legal: false,
+    redemption: false,
+  });
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [formData, setFormData] = useState<AssetEntry | null>(null);
+
+  const headerCell = (label: string) =>
+    // eslint-disable-next-line react/display-name, @typescript-eslint/no-explicit-any
+    ({ column }: { column: any }) => (
+      <button
+        className="max-w-[12rem] truncate font-medium"
+        onClick={() =>
+          column.toggleSorting(column.getIsSorted() === "asc")
+        }
+      >
+        {label}
+      </button>
+    );
 
   const columns: ColumnDef<AssetEntry>[] = [
-    { accessorKey: "name", header: "Asset name" },
-    { accessorKey: "issuer", header: "Issuer name" },
+    { accessorKey: "name", header: headerCell("Asset name") },
+    { accessorKey: "issuer", header: headerCell("Issuer name") },
     {
       accessorKey: "price",
-      header: "Asset price",
+      header: headerCell("Asset price"),
       cell: ({ row }) => `$${row.getValue<number>("price").toFixed(2)}`,
     },
     {
       accessorKey: "priceSource",
-      header: "Price source (URL)",
+      header: headerCell("Price source (URL)"),
       cell: ({ row }) => (
         <Link href={row.getValue<string>("priceSource")}>{"Source"}</Link>
       ),
     },
-    { accessorKey: "amountNest", header: "Amount on Nest" },
-    { accessorKey: "amountUsd", header: "Amount in USD" },
+    { accessorKey: "amountNest", header: headerCell("Amount on Nest") },
+    { accessorKey: "amountUsd", header: headerCell("Amount in USD") },
     {
       accessorKey: "estApy",
-      header: "Estimated APY",
+      header: headerCell("Estimated APY"),
       cell: ({ row }) => `${row.getValue<number>("estApy")}%`,
     },
     {
       accessorKey: "currApy",
-      header: "Current APY",
+      header: headerCell("Current APY"),
       cell: ({ row }) => `${row.getValue<number>("currApy")}%`,
     },
     {
       accessorKey: "apyDiff",
-      header: "APY Difference",
+      header: headerCell("APY Difference"),
       cell: ({ row }) => `${row.getValue<number>("apyDiff")}%`,
     },
-    { accessorKey: "yieldReceived", header: "Yield Received 30D" },
-    { accessorKey: "yieldExpected", header: "Yield Expected 30D" },
-    { accessorKey: "yieldCycle", header: "Yield Payout Cycle" },
-    { accessorKey: "lastPaid", header: "Last Paid" },
-    { accessorKey: "nextPayout", header: "Next Payout Date" },
-    { accessorKey: "jurisdiction", header: "Jurisdiction" },
-    { accessorKey: "legal", header: "Legal Structure" },
-    { accessorKey: "redemption", header: "Redemption Duration" },
+    { accessorKey: "yieldReceived", header: headerCell("Yield Received 30D") },
+    { accessorKey: "yieldExpected", header: headerCell("Yield Expected 30D") },
+    { accessorKey: "yieldCycle", header: headerCell("Yield Payout Cycle") },
+    { accessorKey: "lastPaid", header: headerCell("Last Paid") },
+    { accessorKey: "nextPayout", header: headerCell("Next Payout Date") },
+    { accessorKey: "jurisdiction", header: headerCell("Jurisdiction") },
+    { accessorKey: "legal", header: headerCell("Legal Structure") },
+    { accessorKey: "redemption", header: headerCell("Redemption Duration") },
   ];
 
   const table = useReactTable({
     data,
     columns,
-    state: { columnVisibility },
+    state: { columnVisibility, sorting },
     onColumnVisibilityChange: setColumnVisibility,
+    onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
   });
+  const saveAsset = () => {
+    if (editingIndex === null || !formData) return;
+    const updater = (arr: AssetEntry[]) =>
+      arr.map((a, i) => (i === editingIndex ? formData : a));
+    if (view === "integrated") {
+      setIntegratedData((d) => updater(d));
+    } else {
+      setPendingData((d) => updater(d));
+    }
+  };
 
   return (
-    <div className="p-6 md:p-10 space-y-8">
-      <Tabs value={view} onValueChange={setView} className="w-full space-y-4">
-        <TabsList>
-          <TabsTrigger value="integrated">Integrated</TabsTrigger>
-          <TabsTrigger value="pending">To integrate</TabsTrigger>
-        </TabsList>
+    <div className="p-6 md:p-10 space-y-6">
+      <h1 className="text-2xl font-semibold">Assets</h1>
+      <Tabs value={view} onValueChange={setView} className="space-y-4">
+        <div className="flex items-center justify-between">
+          <TabsList>
+            <TabsTrigger value="integrated">Integrated</TabsTrigger>
+            <TabsTrigger value="pending">To integrate</TabsTrigger>
+          </TabsList>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline">Columns</Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {table.getAllLeafColumns().map((column) => {
+                const label = column.columnDef.header as string;
+                return (
+                  <DropdownMenuCheckboxItem
+                    key={column.id}
+                    checked={column.getIsVisible()}
+                    onCheckedChange={column.toggleVisibility}
+                    onSelect={(e) => e.preventDefault()}
+                  >
+                    {label}
+                  </DropdownMenuCheckboxItem>
+                );
+              })}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
         <TabsContent value={view}>
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between">
-              <CardTitle>Assets</CardTitle>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="outline">Columns</Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  {table.getAllLeafColumns().map((column) => {
-                    const label = column.columnDef.header as string;
-                    return (
-                      <DropdownMenuCheckboxItem
-                        key={column.id}
-                        checked={column.getIsVisible()}
-                        onCheckedChange={column.toggleVisibility}
+          <div className="max-w-full overflow-x-auto">
+            <Table>
+              <TableHeader className="bg-muted">
+                {table.getHeaderGroups().map((hg) => (
+                  <TableRow key={hg.id} className="border-muted">
+                    {hg.headers.map((header) => (
+                      <TableHead key={header.id} className="max-w-[12rem] truncate">
+                        {flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableHeader>
+              <TableBody>
+                {table.getRowModel().rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    className="border-muted cursor-pointer"
+                    onClick={() => {
+                      setEditingIndex(row.index);
+                      setFormData(row.original);
+                    }}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell
+                        key={cell.id}
+                        className="max-w-[12rem] truncate whitespace-nowrap"
                       >
-                        {label}
-                      </DropdownMenuCheckboxItem>
-                    );
-                  })}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </CardHeader>
-            <CardContent className="p-0">
-              <Table>
-                <TableHeader className="bg-muted">
-                  {table.getHeaderGroups().map((hg) => (
-                    <TableRow key={hg.id} className="border-muted">
-                      {hg.headers.map((header) => (
-                        <TableHead key={header.id}>
-                          {flexRender(
-                            header.column.columnDef.header,
-                            header.getContext()
-                          )}
-                        </TableHead>
-                      ))}
-                    </TableRow>
-                  ))}
-                </TableHeader>
-                <TableBody>
-                  {table.getRowModel().rows.map((row) => (
-                    <TableRow key={row.id} className="border-muted">
-                      {row.getVisibleCells().map((cell) => (
-                        <TableCell key={cell.id} className="whitespace-nowrap">
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </TableCell>
-                      ))}
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </CardContent>
-          </Card>
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
         </TabsContent>
       </Tabs>
+
+      <Sheet open={formData !== null} onOpenChange={(o) => !o && setFormData(null)}>
+        <SheetContent side="right">
+          <SheetHeader>
+            <SheetTitle>Edit Asset</SheetTitle>
+          </SheetHeader>
+          {formData && (
+            <form
+              className="space-y-4 overflow-y-auto p-2"
+              onSubmit={(e) => {
+                e.preventDefault();
+                saveAsset();
+                setFormData(null);
+              }}
+            >
+              {Object.entries(formData).map(([key, value]) => (
+                <div key={key} className="space-y-1">
+                  <label className="block text-sm font-medium capitalize">
+                    {key}
+                  </label>
+                  <Input
+                    value={String(value)}
+                    onChange={(e) =>
+                      setFormData({ ...formData, [key]: e.target.value })
+                    }
+                  />
+                </div>
+              ))}
+              <Button type="submit">Save</Button>
+            </form>
+          )}
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- simplify page layout and remove Card wrapper
- add column visibility dropdown and sorting controls
- hide less-used columns by default
- constrain column width and allow horizontal scrolling
- open editable sheet when selecting a row

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6858869338b083288f78b1bcc62cbc5f