### PR TITLE
Fix ColumnMeta label typing

### DIFF
--- a/src/types/react-table.d.ts
+++ b/src/types/react-table.d.ts
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import '@tanstack/react-table'
+import type { RowData } from '@tanstack/react-table'
+
+declare module '@tanstack/react-table' {
+  interface ColumnMeta<_TData extends RowData, _TValue> {
+    label?: string;
+  }
+}
+/* eslint-enable @typescript-eslint/no-unused-vars */


### PR DESCRIPTION
## Summary
- extend `ColumnMeta` to include optional `label` property

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68588ac40ca88328959b4dbdb2e83ed4