### PR TITLE
Fix admin table width

### DIFF
--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -10,7 +10,7 @@ const Table = React.forwardRef<
     <table
       ref={ref}
       className={cn(
-        "caption-bottom text-sm w-max min-w-full",
+        "caption-bottom text-sm w-full table-fixed",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- keep admin table width fixed to prevent layout shifts when columns are toggled

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685903da068483289fc24578c9bb5a4b