### PR TITLE
Improve admin asset details

### DIFF
--- a/src/app/admin/assets/[ticker]/page.tsx
+++ b/src/app/admin/assets/[ticker]/page.tsx
@@ -1,5 +1,5 @@
 import { integratedAssets, pendingAssets } from "../data";
-import ClientPage from "./ClientPage";
+import AssetAdminPage from "./AssetAdminPage";
 
 export default async function Page({ params }: { params: Promise<{ ticker: string }> }) {
   const { ticker } = await params;
@@ -13,5 +13,5 @@ export default async function Page({ params }: { params: Promise<{ ticker: strin
       </div>
     );
   }
-  return <ClientPage asset={asset} />;
+  return <AssetAdminPage asset={asset} />;
 }

--- a/src/app/admin/assets/data.ts
+++ b/src/app/admin/assets/data.ts
@@ -19,6 +19,8 @@ export interface AssetEntry {
   jurisdiction: string;
   legal: string;
   redemption: string;
+  scorecard: string;
+  underwriter: string;
 }
 
 export const integratedAssets: AssetEntry[] = [
@@ -43,6 +45,8 @@ export const integratedAssets: AssetEntry[] = [
     jurisdiction: "US",
     legal: "SPV",
     redemption: "7 days",
+    scorecard: "https://example.com/scorecard/mnrl",
+    underwriter: "Cicada Partners",
   },
   {
     name: "iSNR",
@@ -65,6 +69,8 @@ export const integratedAssets: AssetEntry[] = [
     jurisdiction: "US",
     legal: "Reg D",
     redemption: "14 days",
+    scorecard: "https://example.com/scorecard/isnr",
+    underwriter: "Cicada Partners",
   },
 ];
 
@@ -90,5 +96,7 @@ export const pendingAssets: AssetEntry[] = [
     jurisdiction: "SG",
     legal: "DAO",
     redemption: "-",
+    scorecard: "https://example.com/scorecard/mbasis",
+    underwriter: "Cicada Partners",
   },
 ];


### PR DESCRIPTION
## Summary
- rename ClientPage to AssetAdminPage
- store asset scorecard URL and underwriter
- center admin asset pages and make TVL chart tabbed
- add overall risk score with category bars and activity table
- restrict editing for some fields and enhance editing forms

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68594f1fcc8c8328ad790653b28e92d0