### PR TITLE
Fix admin asset type errors

### DIFF
--- a/src/app/admin/assets/[ticker]/AssetAdminPage.tsx
+++ b/src/app/admin/assets/[ticker]/AssetAdminPage.tsx
@@ -145,6 +145,9 @@ export default function AssetAdminPage({ asset }: { asset: AssetEntry }) {
   const [editingField, setEditingField] = useState<keyof AssetEntry | null>(null);
   const [formData, setFormData] = useState<AssetEntry>(asset);
   const [tvlView, setTvlView] = useState<"asset" | "usd">("asset");
+  const handleTvlViewChange = (value: string) => {
+    setTvlView(value as "asset" | "usd");
+  };
 
   const labels: Record<keyof AssetEntry, string> = {
     name: "Asset name",
@@ -221,7 +224,7 @@ export default function AssetAdminPage({ asset }: { asset: AssetEntry }) {
           <Card>
             <CardHeader className="flex items-center justify-between">
               <CardTitle>{`${asset.ticker} on Nest`}</CardTitle>
-              <Tabs value={tvlView} onValueChange={setTvlView} className="ml-auto">
+              <Tabs value={tvlView} onValueChange={handleTvlViewChange} className="ml-auto">
                 <TabsList>
                   <TabsTrigger value="asset">{asset.ticker}</TabsTrigger>
                   <TabsTrigger value="usd">USD</TabsTrigger>

--- a/src/app/admin/assets/page.tsx
+++ b/src/app/admin/assets/page.tsx
@@ -230,6 +230,8 @@ export default function AssetsPage() {
     jurisdiction: "Jurisdiction",
     legal: "Legal Structure",
     redemption: "Redemption Duration",
+    scorecard: "Scorecard",
+    underwriter: "Underwriter",
   };
 
   const table = useReactTable({


### PR DESCRIPTION
## Summary
- add a handler for TVL tab changes to satisfy Tabs prop types
- include `scorecard` and `underwriter` labels in asset table

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685951892470832887b8dd77c6115805