### PR TITLE
Fix AssetAdmin labels typing

### DIFF
--- a/src/app/admin/assets/[ticker]/AssetAdminPage.tsx
+++ b/src/app/admin/assets/[ticker]/AssetAdminPage.tsx
@@ -154,7 +154,7 @@ export default function AssetAdminPage({ asset }: { asset: AssetEntry }) {
   const latestApy = apyHistory[apyHistory.length - 1].apy;
   const latestPrice = priceHistory[priceHistory.length - 1].price;
 
-  const labels: Record<keyof AssetEntry, string> = {
+  const labels: Partial<Record<keyof AssetEntry, string>> = {
     name: "Asset name",
     ticker: "Ticker",
     contract: "Contract",
@@ -315,7 +315,7 @@ export default function AssetAdminPage({ asset }: { asset: AssetEntry }) {
                   <div key={k} className="flex items-center gap-2">
                     <div className="flex-1">
                       <div className="text-sm text-muted-foreground">{labels[k]}</div>
-                      <div>{formData[k]}</div>
+                      <div>{String(formData[k])}</div>
                     </div>
                     {!readOnlyFields.includes(k) && (
                       <Button

--- a/src/app/admin/assets/page.tsx
+++ b/src/app/admin/assets/page.tsx
@@ -218,7 +218,7 @@ export default function AssetsPage() {
     },
   ];
 
-  const labels: Record<keyof AssetEntry, string> = {
+  const labels: Partial<Record<keyof AssetEntry, string>> = {
     name: "Asset name",
     ticker: "Ticker",
     contract: "Contract",


### PR DESCRIPTION
## Summary
- update labels objects to be `Partial<Record<...>>`
- convert displayed values to strings

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685959bb7580832887e1ede173b7a2f7