### PR TITLE
Fix admin asset page layout

### DIFF
--- a/src/app/admin/assets/[ticker]/AssetAdminPage.tsx
+++ b/src/app/admin/assets/[ticker]/AssetAdminPage.tsx
@@ -198,8 +198,8 @@ export default function AssetAdminPage({ asset }: { asset: AssetEntry }) {
   ];
 
   return (
-    <div className="p-6 md:p-10 w-full">
-      <div className="mx-auto max-w-5xl space-y-8">
+    <div className="flex h-full w-full items-center justify-center p-6 md:p-10">
+      <div className="w-[800px] space-y-8">
       <Breadcrumb>
         <BreadcrumbList>
           <BreadcrumbItem>


### PR DESCRIPTION
## Summary
- make asset admin page stretch to full width
- center asset page content and set it to 800px

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68595d90e6808328b50e7085a8229a8e