### PR TITLE
Fix asset page container width

### DIFF
--- a/src/app/admin/assets/[ticker]/AssetAdminPage.tsx
+++ b/src/app/admin/assets/[ticker]/AssetAdminPage.tsx
@@ -198,8 +198,8 @@ export default function AssetAdminPage({ asset }: { asset: AssetEntry }) {
   ];
 
   return (
-    <div className="p-6 md:p-10 w-full">
-      <div className="mx-auto max-w-5xl space-y-8">
+    <div className="flex items-center justify-center w-full h-full p-6 md:p-10">
+      <div className="w-full max-w-[800px] space-y-8">
       <Breadcrumb>
         <BreadcrumbList>
           <BreadcrumbItem>

--- a/src/app/admin/assets/[ticker]/page.tsx
+++ b/src/app/admin/assets/[ticker]/page.tsx
@@ -8,7 +8,7 @@ export default async function Page({ params }: { params: Promise<{ ticker: strin
   );
   if (!asset) {
     return (
-      <div className="p-6 md:p-10">
+      <div className="flex items-center justify-center w-full h-full p-6 md:p-10">
         <p>Asset not found.</p>
       </div>
     );


### PR DESCRIPTION
## Summary
- center asset pages within admin and limit to 800px width
- center not-found message for consistency

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68595ff3415083288a00666c2deaf4bd