### PR TITLE
Fix asset detail width

### DIFF
--- a/src/app/admin/assets/[ticker]/AssetAdminPage.tsx
+++ b/src/app/admin/assets/[ticker]/AssetAdminPage.tsx
@@ -199,7 +199,7 @@ export default function AssetAdminPage({ asset }: { asset: AssetEntry }) {
 
   return (
     <div className="p-6 md:p-10 w-full flex flex-col items-center">
-      <div className="mx-auto w-full max-w-5xl space-y-8">
+      <div className="mx-auto w-full space-y-8">
       <Breadcrumb>
         <BreadcrumbList>
           <BreadcrumbItem>

--- a/src/app/mineral/page.tsx
+++ b/src/app/mineral/page.tsx
@@ -483,7 +483,7 @@ export default function VaultPage() {
   }
 
   return (
-    <div className="p-6 md:p-10 grid md:grid-cols-[1fr_320px] gap-6 max-w-[1080px] mx-auto">
+    <div className="p-6 md:p-10 grid md:grid-cols-[1fr_320px] gap-6 w-full mx-auto">
       <div className="flex flex-col gap-6">
         <div className="space-y-2">
           <Breadcrumb>


### PR DESCRIPTION
## Summary
- remove width caps from asset detail page containers so width remains full across tabs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685966784ba08328a174b5ba456376c9