### PR TITLE
Fix asset detail layout width

### DIFF
--- a/src/app/admin/assets/[ticker]/AssetAdminPage.tsx
+++ b/src/app/admin/assets/[ticker]/AssetAdminPage.tsx
@@ -198,8 +198,8 @@ export default function AssetAdminPage({ asset }: { asset: AssetEntry }) {
   ];
 
   return (
-    <div className="p-6 md:p-10 w-full flex flex-col items-center">
-      <div className="mx-auto w-full max-w-5xl space-y-8">
+    <div className="p-6 md:p-10 w-full flex flex-col">
+      <div className="mx-auto w-full space-y-8">
       <Breadcrumb>
         <BreadcrumbList>
           <BreadcrumbItem>


### PR DESCRIPTION
## Summary
- expand asset detail page to use full available width

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685968949a008328b49e944641d837ad